### PR TITLE
Исправляем ошибку при инициализации модели com_users Registration

### DIFF
--- a/com_slogin/site/controller.php
+++ b/com_slogin/site/controller.php
@@ -387,6 +387,8 @@ class SLoginController extends SLoginControllerParent
         $model	= $this->getModel('Registration', 'UsersModel');
 
 		$username = $this->CheckUniqueName($this->username);
+		// добавляем в список путей JForm пути форм com_users, т.к. при вызове модели не из родной компоненты форма не будет найдена
+		JForm::addFormPath(JPATH_ROOT. '/components/com_users/models/forms');
 
         $userId	= (int)$model->register(
             array(


### PR DESCRIPTION
При вызове метода UsersModelRegistration->register не создавался класс формы JForm,
это вызывало FatalError на **мультиязычных** сайтах при вызове `$form->setFieldAttribute()`
`/components/com_users/models/registration.php on line 307`.
Решение: до вызова UsersModelRegistration->register требуется добавить пути к формам com_users в список путей JForm.
fix #85