### PR TITLE
fix com_slogin/controller - looks have typewritel bug about provider name

### DIFF
--- a/com_slogin/site/controller.php
+++ b/com_slogin/site/controller.php
@@ -206,7 +206,7 @@ class SLoginController extends SLoginControllerParent
 	        JPluginHelper::importPlugin('slogin_integration');
 
 	        $dispatcher->trigger('onSloginBeforeStoreOrLogin', array(
-		        $request->provider,
+	            $this->provider,
 		        &$this->first_name,
 		        &$this->last_name,
 		        &$this->email,


### PR DESCRIPTION
com_slogin/controller - looks have typewritel bug about provider name. That was confusing success auth.

* to event onSloginBeforeStoreOrLogin pass provider info prepared in $this->provider,
  but actualy code pass $request->provider. this one field is absent, and pass just ""
  instead auth privider name.
  looks here is typewrite mistake.